### PR TITLE
Admin Route Redirection

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,11 @@ const nextConfig = {
         source: '/job-openings.php',
         destination: '/contact',
         permanent: true
+      },
+      {
+        source: '/admin',
+        destination: '/admin/index.html',
+        permanent: true,
       }
     ]
   }


### PR DESCRIPTION
correct the redirection of `/admin` route for blog posts of DecapCMS.